### PR TITLE
Change colour of links to pass the WCAG contrast ratio guidelines and…

### DIFF
--- a/css/natureofcode.css
+++ b/css/natureofcode.css
@@ -49,7 +49,7 @@ html {
   font-family: 'Georgia'; }
 
 a {
-  color: #30def6; }
+  color: #237480; }
 
 em {
   font-style: italic; }
@@ -220,7 +220,7 @@ h3 #display-percent {
     cursor: pointer; }
 
 .block-link {
-  background-color: #1ed4ed;
+  background-color: #237480;
   color: #fff;
   border: none;
   display: inline-block;


### PR DESCRIPTION
… make them readable

Current colour #30def6 has a low contrast ratio with the background colour #f6f6f6 and may be unreadable for some people. Does not pass test on https://contrast-ratio.com/. New colour #237480 does pass this test.