### PR TITLE
make page navigator accessible

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -13,7 +13,15 @@
   <script type="text/javascript" charset="utf-8">
     $(document).ready(function(){
       $('#toc-list').fixed({'top':'8'});
-      $('#nav-bar-wrap').fixed({'top':'8'});
+      $('#nav-bar-wrap').fixed({'top':'8'}, function(status, changed, ele) {
+          if (changed) {
+              if (status !== 'fixed') {
+                  $('#nav-bar-wrap').addClass("hidden");
+              } else {
+                  $('#nav-bar-wrap').removeClass("hidden");
+              }
+          }
+      });
 
       $('span.c1').each(function(){ addStylesToCodeLines($(this)); });
       // $('code').each(function(){ inlineComments($(this)); });
@@ -57,7 +65,7 @@
 
   <div id="navigator">
     <div id="navigator-inner">
-      <div id='nav-bar-wrap'>
+      <div id='nav-bar-wrap' class="hidden">
         <div id="mask"></div>
         <div id="nav-bar">
           <h1><a href="/">THE <strong>NATURE</strong> OF CODE</a></h1>
@@ -67,7 +75,7 @@
       </div>
       <div id="toc-holder">
         <div id="toc-list">
-          <ul>
+          <ul aria-label="table of contents" role="list">
             <li><a href="/book/">Welcome</a></li>
             <li><a href="/book/acknowledgments">Acknowledgments</a></li>
             <li><a href="/book/dedication">Dedication</a></li>

--- a/book/javascripts/jquery.fixed.js
+++ b/book/javascripts/jquery.fixed.js
@@ -6,7 +6,7 @@
 
 (function( $ ){
 
-	$.fn.fixed = function( options ) {
+	$.fn.fixed = function( options, callback = null ) {
 
 		var settings = {
 			'top'	: 0
@@ -59,14 +59,17 @@
 			}
 
 			function setFixed() {
+                if (callback) callback('fixed', $this.css('position') !== 'fixed', $this);
 				$this.css('position','fixed').css('top', settings.top+'px');
 			};
 
 			function setAb() {
+                if (callback) callback('absolute', $this.css('position') !== 'absolute', $this);
 				$this.css('position','absolute').css('top', '0px');
 			};
 
 			function setRel() {
+                if (callback) callback('relative', $this.css('position') !== 'relative', $this);
 				$this.css('position','relative').css('top','auto');
 			}
 

--- a/book/stylesheets/html.css
+++ b/book/stylesheets/html.css
@@ -123,6 +123,25 @@ _____________________________________________________________________________*/
   box-sizing: border-box;
 }
 
+#nav-bar-wrap.hidden:focus-within {
+    z-index: 4;
+}
+
+#nav-bar-wrap.hidden:focus-within #mask {
+    background-color: transparent;
+}
+
+#nav-bar-wrap.hidden:focus-within #nav-bar {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+}
+
+#nav-bar > *:focus {
+    background-color: rgb(235,0,90);
+    z-index: 99;
+}
+
 #nav-bar-wrap {
   margin: 0;
   position: absolute;


### PR DESCRIPTION
I did the following change to make `/book` page more accessible especially for *VoiceOver*:

- Add a description for list of `table of content` so that *VoiceOver* can hit users what list they are accessing.

<img width="655" alt="figure 0" src="https://user-images.githubusercontent.com/18514672/46628173-b6b18980-cb0a-11e8-99ee-568106f8a05a.png">

- Improve the user experience of top navigator bar. Originally, User can focus but can see nothing since all buttons are covered by an upper division (figure 1). Now, users can see what is selected if 
 (and only if) they use *VoiceOver* buttons to focus that button (figure 2), otherwise these buttons are hidden as original.

<img width="847" alt="figure 1" src="https://user-images.githubusercontent.com/18514672/46628512-cc737e80-cb0b-11e8-956d-f478d33a0ca1.png">

<img width="1297" alt="figure 2" src="https://user-images.githubusercontent.com/18514672/46628526-d4cbb980-cb0b-11e8-9a9e-548f5c123702.png">
