### PR TITLE
Example 3.9: Remove code from comment.

### DIFF
--- a/book/chapter-3-oscillation/index.html
+++ b/book/chapter-3-oscillation/index.html
@@ -1492,8 +1492,9 @@ void setup() {
 void draw() {
   background(255);
 
-  //[full] In order to move the wave, we start at a different theta value each frame.  startAngle += 0.02;
-float angle = startAngle;
+  //[full] In order to move the wave, we start at a different theta value each frame.
+  startAngle += 0.02;
+  float angle = startAngle;
   //[end]
 
   for (int x = 0; x <= width; x += 24) {

--- a/natureofcode2.0/book/chapter-3-oscillation/index.html
+++ b/natureofcode2.0/book/chapter-3-oscillation/index.html
@@ -1492,8 +1492,9 @@ void setup() {
 void draw() {
   background(255);
 
-  //[full] In order to move the wave, we start at a different theta value each frame.  startAngle += 0.02;
-float angle = startAngle;
+  //[full] In order to move the wave, we start at a different theta value each frame.
+  startAngle += 0.02;
+  float angle = startAngle;
   //[end]
 
   for (int x = 0; x <= width; x += 24) {


### PR DESCRIPTION
One statement is shown as part of the comment rather than a line of code.
Move the statement so that it appears correctly in the code listing.

References #26.