### PR TITLE
Removing lifetime message as of 4/26/23

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@ How can we capture the unpredictable evolutionary and emergent properties of nat
             <li>DRM-free</li>
             <li>includes PDF, ePub, and Kindle formats</li>
             <li>Delivered by email, no login necessary</li>
-            <li>Receive lifetime book updates for free</li>
           </ul>
 
           <form method="POST" action="https://natureofcode.herokuapp.com/order" id="slider-form">


### PR DESCRIPTION
I have a record of everyone who purchased the 2012 digital edition of the book and will gladly share a digital version of the new book when it is ready, but it may have to be a "opt-in" as I will likely deprecate the current automated updates via fetchapp.com. The book will always be freely available in HTML at natureofcode.com (work in progress of new version is here: https://nature-of-code-2nd-edition.netlify.app/)